### PR TITLE
Add FTP Service Resources & Access

### DIFF
--- a/groups/wck-infrastructure/alb_external.tf
+++ b/groups/wck-infrastructure/alb_external.tf
@@ -9,7 +9,11 @@ module "wck_external_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = var.fe_public_access_cidrs
+  ingress_cidr_blocks = concat(
+    var.fe_public_access_cidrs,
+    formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_external : eni.private_ip])
+  )
+
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
   egress_rules        = ["all-all"]
 }

--- a/groups/wck-infrastructure/alb_internal.tf
+++ b/groups/wck-infrastructure/alb_internal.tf
@@ -9,7 +9,11 @@ module "wck_internal_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = local.admin_cidrs
+  ingress_cidr_blocks = concat(
+    local.admin_cidrs,
+    formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip])
+  )
+
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
 
   ingress_with_cidr_blocks = local.fe_alb_app_access

--- a/groups/wck-infrastructure/asg_frontend.tf
+++ b/groups/wck-infrastructure/asg_frontend.tf
@@ -9,6 +9,65 @@ module "wck_fe_asg_security_group" {
   description = "Security group for the ${var.application} frontend asg"
   vpc_id      = data.aws_vpc.vpc.id
 
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 21
+      to_port     = 21
+      protocol    = "tcp"
+      description = "Allow FTP connections from internal networks"
+      cidr_blocks = join(",", local.admin_cidrs)
+    },
+    {
+      from_port   = var.fe_ftp_int_passive_ports_start
+      to_port     = var.fe_ftp_int_passive_ports_end
+      protocol    = "tcp"
+      description = "Allow FTP passive connections from internal networks"
+      cidr_blocks = join(",", local.admin_cidrs)
+    },
+    {
+      from_port   = 21
+      to_port     = 21
+      protocol    = "tcp"
+      description = "Allow FTP connections from internal NLB"
+      cidr_blocks = join(",", formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip]))
+    },
+    {
+      from_port   = var.fe_ftp_int_passive_ports_start
+      to_port     = var.fe_ftp_int_passive_ports_end
+      protocol    = "tcp"
+      description = "Allow FTP passive connections from internal NLB"
+      cidr_blocks = join(",", formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip]))
+    },
+    {
+      from_port   = 2121
+      to_port     = 2121
+      protocol    = "tcp"
+      description = "Allow FTP connections from external NLB"
+      cidr_blocks = join(",", formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_external : eni.private_ip]))
+    },
+    {
+      from_port   = var.fe_ftp_ext_passive_ports_start
+      to_port     = var.fe_ftp_ext_passive_ports_end
+      protocol    = "tcp"
+      description = "Allow FTP passive connections from external NLB"
+      cidr_blocks = join(",", formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_external : eni.private_ip]))
+    },
+    {
+      from_port   = 2121
+      to_port     = 2121
+      protocol    = "tcp"
+      description = "Allow FTP connections from external"
+      cidr_blocks = join(",", var.fe_public_access_cidrs)
+    },
+    {
+      from_port   = var.fe_ftp_ext_passive_ports_start
+      to_port     = var.fe_ftp_ext_passive_ports_end
+      protocol    = "tcp"
+      description = "Allow FTP passive connections from external"
+      cidr_blocks = join(",", var.fe_public_access_cidrs)
+    },
+  ]
+
   computed_ingress_with_source_security_group_id = [
     {
       rule                     = "http-80-tcp"

--- a/groups/wck-infrastructure/data.tf
+++ b/groups/wck-infrastructure/data.tf
@@ -148,6 +148,19 @@ data "template_cloudinit_config" "fe_userdata_config" {
   base64_encode = true
 
   part {
+    content_type = "text/cloud-config"
+    content = templatefile("${path.module}/templates/fe_ftp_server.tpl", {
+      int_passive_ports_start = var.fe_ftp_int_passive_ports_start
+      int_passive_ports_end   = var.fe_ftp_int_passive_ports_end
+      internal_nlb_name       = module.nlb_fe_internal.this_lb_dns_name
+      ext_passive_ports_start = var.fe_ftp_ext_passive_ports_start
+      ext_passive_ports_end   = var.fe_ftp_ext_passive_ports_end
+      external_nlb_name       = module.nlb_fe_external.this_lb_dns_name
+      root_dir                = var.fe_ftp_root_dir
+    })
+  }
+
+  part {
     content_type = "text/x-shellscript"
     content      = data.template_file.fe_userdata.rendered
   }

--- a/groups/wck-infrastructure/locals.tf
+++ b/groups/wck-infrastructure/locals.tf
@@ -51,6 +51,64 @@ locals {
     }
   ] : []
 
+  # Generate listener configuration for FTP passive ports
+  wck_fe_ftp_int_passive_listeners = [
+    for num in range(var.fe_ftp_int_passive_ports_start, var.fe_ftp_int_passive_ports_end + 1) : {
+      port               = format("%d", num)
+      protocol           = "TCP"
+    }
+  ]
+  wck_fe_ftp_ext_passive_listeners = [
+    for num in range(var.fe_ftp_ext_passive_ports_start, var.fe_ftp_ext_passive_ports_end + 1) : {
+      port               = format("%d", num)
+      protocol           = "TCP"
+    }
+  ]
+
+  # Generate target group configuration for FTP passive ports
+  # Internal NLB TGs
+  wck_fe_internal_ftp_passive_tgs = [
+    for num in range(var.fe_ftp_int_passive_ports_start, var.fe_ftp_int_passive_ports_end + 1) : {
+      name                 = "tg-${var.application}-fe-int-ftp-${num}"
+      backend_protocol     = "TCP"
+      backend_port         = num
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 21
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    }
+  ]
+
+  # External NLB TGs
+  wck_fe_external_ftp_passive_tgs = [
+    for num in range(var.fe_ftp_ext_passive_ports_start, var.fe_ftp_ext_passive_ports_end + 1) : {
+      name                 = "tg-${var.application}-fe-ext-ftp-${num}"
+      backend_protocol     = "TCP"
+      backend_port         = num
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 2121
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    }
+  ]
 
   wck_fe_ansible_inputs = {
     s3_bucket_releases         = local.s3_releases["release_bucket_name"]

--- a/groups/wck-infrastructure/nlb_fe_external.tf
+++ b/groups/wck-infrastructure/nlb_fe_external.tf
@@ -1,0 +1,120 @@
+data "aws_network_interface" "nlb_fe_external" {
+  for_each = data.aws_subnet_ids.public.ids
+
+  filter {
+    name   = "description"
+    values = ["ELB ${module.nlb_fe_external.this_lb_arn_suffix}"]
+  }
+
+  filter {
+    name   = "subnet-id"
+    values = [each.value]
+  }
+}
+
+module "nlb_fe_external" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 5.0"
+
+  name                       = "nlb-${var.application}-fe-external-001"
+  vpc_id                     = data.aws_vpc.vpc.id
+  internal                   = false
+  load_balancer_type         = "network"
+  enable_deletion_protection = true
+
+  subnets                    = data.aws_subnet_ids.public.ids
+
+  http_tcp_listeners = concat([
+    {
+      port               = 80
+      protocol           = "TCP"
+      target_group_index = 0
+    },
+    {
+      port               = 443
+      protocol           = "TCP"
+      target_group_index = 1
+    },
+    {
+      port               = 21
+      protocol           = "TCP"
+      target_group_index = 2
+    }
+  ],
+  local.wck_fe_ftp_ext_passive_listeners)
+
+  target_groups = concat([
+    {
+      name                 = "tg-${var.application}-fe-external-alb-001"
+      backend_protocol     = "TCP"
+      backend_port         = 80
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.wck_external_alb.this_lb_arn
+          port             = 80
+        }
+      ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-external-alb-002"
+      backend_protocol     = "TCP"
+      backend_port         = 443
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.wck_external_alb.this_lb_arn
+          port             = 443
+        }
+      ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-external-ftp-001"
+      backend_protocol     = "TCP"
+      backend_port         = 2121
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 2121
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+  ],
+  local.wck_fe_external_ftp_passive_tgs)
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-FE-Support"
+    )
+  )
+}

--- a/groups/wck-infrastructure/nlb_fe_internal.tf
+++ b/groups/wck-infrastructure/nlb_fe_internal.tf
@@ -1,0 +1,120 @@
+data "aws_network_interface" "nlb_fe_internal" {
+  for_each = data.aws_subnet_ids.web.ids
+
+  filter {
+    name   = "description"
+    values = ["ELB ${module.nlb_fe_internal.this_lb_arn_suffix}"]
+  }
+
+  filter {
+    name   = "subnet-id"
+    values = [each.value]
+  }
+}
+
+module "nlb_fe_internal" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 5.0"
+
+  name                       = "nlb-${var.application}-fe-internal-001"
+  vpc_id                     = data.aws_vpc.vpc.id
+  internal                   = true
+  load_balancer_type         = "network"
+  enable_deletion_protection = true
+
+  subnets                    = data.aws_subnet_ids.web.ids
+
+  http_tcp_listeners = concat([
+    {
+      port               = 80
+      protocol           = "TCP"
+      target_group_index = 0
+    },
+    {
+      port               = 443
+      protocol           = "TCP"
+      target_group_index = 1
+    },
+    {
+      port               = 21
+      protocol           = "TCP"
+      target_group_index = 2
+    }
+  ],
+  local.wck_fe_ftp_int_passive_listeners)
+
+  target_groups = concat([
+    {
+      name                 = "tg-${var.application}-fe-internal-alb-001"
+      backend_protocol     = "TCP"
+      backend_port         = 80
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.wck_internal_alb.this_lb_arn
+          port             = 80
+        }
+      ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-internal-alb-002"
+      backend_protocol     = "TCP"
+      backend_port         = 443
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.wck_internal_alb.this_lb_arn
+          port             = 443
+        }
+      ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-internal-ftp-001"
+      backend_protocol     = "TCP"
+      backend_port         = 21
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 21
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    }
+  ],
+  local.wck_fe_internal_ftp_passive_tgs)
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-FE-Support"
+    )
+  )
+}

--- a/groups/wck-infrastructure/outputs.tf
+++ b/groups/wck-infrastructure/outputs.tf
@@ -1,3 +1,3 @@
 output "wck_frontend_address_internal" {
-  value = aws_route53_record.wck_alb_internal.fqdn
+  value = aws_route53_record.wck_frontend_internal.fqdn
 }

--- a/groups/wck-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/wck-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -24,6 +24,12 @@ fe_public_access_cidrs = [
   "127.0.0.1/32"
 ]
 
+fe_ftp_int_passive_ports_start = 60401
+fe_ftp_int_passive_ports_end   = 60410
+fe_ftp_ext_passive_ports_start = 60451
+fe_ftp_ext_passive_ports_end   = 60460
+fe_ftp_root_dir = "/mnt/nfs/wck/"
+
 fe_cw_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"
@@ -62,6 +68,11 @@ fe_cw_logs = {
 
   "wck_error_log" = {
     file_path = "/etc/httpd/logs"
+    log_group_retention = 7
+  }
+
+  "ftp_xfer_log" = {
+    file_path = "/var/log/xferlog"
     log_group_retention = 7
   }
 }

--- a/groups/wck-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/wck-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -63,6 +63,10 @@ fe_cw_logs = {
     log_group_retention = 7
   }
 
+  "ftp_xfer_log" = {
+    file_path = "/var/log/xferlog"
+    log_group_retention = 7
+  }
 }
 
 # ------------------------------------------------------------------------------

--- a/groups/wck-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/wck-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -24,6 +24,12 @@ fe_public_access_cidrs = [
   "127.0.0.1/32"
 ]
 
+fe_ftp_int_passive_ports_start = 60401
+fe_ftp_int_passive_ports_end   = 60410
+fe_ftp_ext_passive_ports_start = 60451
+fe_ftp_ext_passive_ports_end   = 60460
+fe_ftp_root_dir = "/mnt/nfs/wck/"
+
 fe_cw_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"
@@ -62,6 +68,11 @@ fe_cw_logs = {
 
   "wck_error_log" = {
     file_path = "/etc/httpd/logs"
+    log_group_retention = 7
+  }
+
+  "ftp_xfer_log" = {
+    file_path = "/var/log/xferlog"
     log_group_retention = 7
   }
 }

--- a/groups/wck-infrastructure/route53.tf
+++ b/groups/wck-infrastructure/route53.tf
@@ -1,11 +1,11 @@
-resource "aws_route53_record" "wck_alb_internal" {
+resource "aws_route53_record" "wck_frontend_internal" {
   zone_id = data.aws_route53_zone.private_zone.zone_id
   name    = var.application
   type    = "A"
 
   alias {
-    name                   = module.wck_internal_alb.this_lb_dns_name
-    zone_id                = module.wck_internal_alb.this_lb_zone_id
+    name                   = module.nlb_fe_internal.this_lb_dns_name
+    zone_id                = module.nlb_fe_internal.this_lb_zone_id
     evaluate_target_health = true
   }
 }

--- a/groups/wck-infrastructure/templates/fe_ftp_server.tpl
+++ b/groups/wck-infrastructure/templates/fe_ftp_server.tpl
@@ -1,0 +1,258 @@
+write_files:
+  - path: /etc/vsftpd/vsftpd.conf
+    owner: root:root
+    permissions: 0600
+    content: |
+      # Allow anonymous FTP? (Beware - allowed by default if you comment this out).
+      anonymous_enable=YES
+      anon_root=${root_dir}
+      dirlist_enable=no
+      #
+      # Uncomment this to allow local users to log in.
+      local_enable=NO
+      #
+      # Uncomment this to enable any form of FTP write command.
+      write_enable=NO
+      #
+      # Default umask for local users is 077. You may wish to change this to 022,
+      # if your users expect that (022 is used by most other ftpd's)
+      local_umask=022
+      #
+      # Uncomment this to allow the anonymous FTP user to upload files. This only
+      # has an effect if the above global write enable is activated. Also, you will
+      # obviously need to create a directory writable by the FTP user.
+      #anon_upload_enable=YES
+      #
+      # Uncomment this if you want the anonymous FTP user to be able to create
+      # new directories.
+      #anon_mkdir_write_enable=YES
+      #
+      # Activate directory messages - messages given to remote users when they
+      # go into a certain directory.
+      dirmessage_enable=YES
+      #
+      # The target log file can be vsftpd_log_file or xferlog_file.
+      # This depends on setting xferlog_std_format parameter
+      xferlog_enable=YES
+      #
+      # Make sure PORT transfer connections originate from port 20 (ftp-data).
+      connect_from_port_20=YES
+      #
+      # If you want, you can arrange for uploaded anonymous files to be owned by
+      # a different user. Note! Using "root" for uploaded files is not
+      # recommended!
+      #chown_uploads=YES
+      #chown_username=whoever
+      #
+      # The name of log file when xferlog_enable=YES and xferlog_std_format=YES
+      # WARNING - changing this filename affects /etc/logrotate.d/vsftpd.log
+      #xferlog_file=/var/log/xferlog
+      #
+      # Switches between logging into vsftpd_log_file and xferlog_file files.
+      # NO writes to vsftpd_log_file, YES to xferlog_file
+      xferlog_std_format=YES
+      #
+      # You may change the default value for timing out an idle session.
+      #idle_session_timeout=600
+      #
+      # You may change the default value for timing out a data connection.
+      #data_connection_timeout=120
+      #
+      # It is recommended that you define on your system a unique user which the
+      # ftp server can use as a totally isolated and unprivileged user.
+      #nopriv_user=ftpsecure
+      #
+      # Enable this and the server will recognise asynchronous ABOR requests. Not
+      # recommended for security (the code is non-trivial). Not enabling it,
+      # however, may confuse older FTP clients.
+      #async_abor_enable=YES
+      #
+      # By default the server will pretend to allow ASCII mode but in fact ignore
+      # the request. Turn on the below options to have the server actually do ASCII
+      # mangling on files when in ASCII mode.
+      # Beware that on some FTP servers, ASCII support allows a denial of service
+      # attack (DoS) via the command "SIZE /big/file" in ASCII mode. vsftpd
+      # predicted this attack and has always been safe, reporting the size of the
+      # raw file.
+      # ASCII mangling is a horrible feature of the protocol.
+      #ascii_upload_enable=YES
+      #ascii_download_enable=YES
+      #
+      # You may fully customise the login banner string:
+      ftpd_banner=Companies House WebCHeck
+      #
+      # You may specify a file of disallowed anonymous e-mail addresses. Apparently
+      # useful for combatting certain DoS attacks.
+      #deny_email_enable=YES
+      # (default follows)
+      #banned_email_file=/etc/vsftpd/banned_emails
+      #
+      # You may specify an explicit list of local users to chroot() to their home
+      # directory. If chroot_local_user is YES, then this list becomes a list of
+      # users to NOT chroot().
+      #chroot_local_user=YES
+      #chroot_list_enable=YES
+      # (default follows)
+      #chroot_list_file=/etc/vsftpd/chroot_list
+      #
+      # You may activate the "-R" option to the builtin ls. This is disabled by
+      # default to avoid remote users being able to cause excessive I/O on large
+      # sites. However, some broken FTP clients such as "ncftp" and "mirror" assume
+      # the presence of the "-R" option, so there is a strong case for enabling it.
+      #ls_recurse_enable=YES
+      #
+      # When "listen" directive is enabled, vsftpd runs in standalone mode and
+      # listens on IPv4 sockets. This directive cannot be used in conjunction
+      # with the listen_ipv6 directive.
+      listen=YES
+      listen_port=21
+      #
+      # This directive enables listening on IPv6 sockets. To listen on IPv4 and IPv6
+      # sockets, you must run two copies of vsftpd with two configuration files.
+      # Make sure, that one of the listen options is commented !!
+      #listen_ipv6=YES
+
+      pam_service_name=vsftpd
+      userlist_enable=YES
+      tcp_wrappers=YES
+
+      # Passive config
+      pasv_enable=YES
+      pasv_max_port=${int_passive_ports_end}
+      pasv_min_port=${int_passive_ports_start}
+      pasv_address=
+
+  - path: /etc/vsftpd/vsftpd-external.conf
+    owner: root:root
+    permissions: 0600
+    content: |
+      # Allow anonymous FTP? (Beware - allowed by default if you comment this out).
+      anonymous_enable=YES
+      anon_root=${root_dir}
+      dirlist_enable=no
+      #
+      # Uncomment this to allow local users to log in.
+      local_enable=NO
+      #
+      # Uncomment this to enable any form of FTP write command.
+      write_enable=NO
+      #
+      # Default umask for local users is 077. You may wish to change this to 022,
+      # if your users expect that (022 is used by most other ftpd's)
+      local_umask=022
+      #
+      # Uncomment this to allow the anonymous FTP user to upload files. This only
+      # has an effect if the above global write enable is activated. Also, you will
+      # obviously need to create a directory writable by the FTP user.
+      #anon_upload_enable=YES
+      #
+      # Uncomment this if you want the anonymous FTP user to be able to create
+      # new directories.
+      #anon_mkdir_write_enable=YES
+      #
+      # Activate directory messages - messages given to remote users when they
+      # go into a certain directory.
+      dirmessage_enable=YES
+      #
+      # The target log file can be vsftpd_log_file or xferlog_file.
+      # This depends on setting xferlog_std_format parameter
+      xferlog_enable=YES
+      #
+      # Make sure PORT transfer connections originate from port 20 (ftp-data).
+      connect_from_port_20=YES
+      #
+      # If you want, you can arrange for uploaded anonymous files to be owned by
+      # a different user. Note! Using "root" for uploaded files is not
+      # recommended!
+      #chown_uploads=YES
+      #chown_username=whoever
+      #
+      # The name of log file when xferlog_enable=YES and xferlog_std_format=YES
+      # WARNING - changing this filename affects /etc/logrotate.d/vsftpd.log
+      #xferlog_file=/var/log/xferlog
+      #
+      # Switches between logging into vsftpd_log_file and xferlog_file files.
+      # NO writes to vsftpd_log_file, YES to xferlog_file
+      xferlog_std_format=YES
+      #
+      # You may change the default value for timing out an idle session.
+      #idle_session_timeout=600
+      #
+      # You may change the default value for timing out a data connection.
+      #data_connection_timeout=120
+      #
+      # It is recommended that you define on your system a unique user which the
+      # ftp server can use as a totally isolated and unprivileged user.
+      #nopriv_user=ftpsecure
+      #
+      # Enable this and the server will recognise asynchronous ABOR requests. Not
+      # recommended for security (the code is non-trivial). Not enabling it,
+      # however, may confuse older FTP clients.
+      #async_abor_enable=YES
+      #
+      # By default the server will pretend to allow ASCII mode but in fact ignore
+      # the request. Turn on the below options to have the server actually do ASCII
+      # mangling on files when in ASCII mode.
+      # Beware that on some FTP servers, ASCII support allows a denial of service
+      # attack (DoS) via the command "SIZE /big/file" in ASCII mode. vsftpd
+      # predicted this attack and has always been safe, reporting the size of the
+      # raw file.
+      # ASCII mangling is a horrible feature of the protocol.
+      #ascii_upload_enable=YES
+      #ascii_download_enable=YES
+      #
+      # You may fully customise the login banner string:
+      ftpd_banner=Companies House WebCHeck
+      #
+      # You may specify a file of disallowed anonymous e-mail addresses. Apparently
+      # useful for combatting certain DoS attacks.
+      #deny_email_enable=YES
+      # (default follows)
+      #banned_email_file=/etc/vsftpd/banned_emails
+      #
+      # You may specify an explicit list of local users to chroot() to their home
+      # directory. If chroot_local_user is YES, then this list becomes a list of
+      # users to NOT chroot().
+      #chroot_local_user=YES
+      #chroot_list_enable=YES
+      # (default follows)
+      #chroot_list_file=/etc/vsftpd/chroot_list
+      #
+      # You may activate the "-R" option to the builtin ls. This is disabled by
+      # default to avoid remote users being able to cause excessive I/O on large
+      # sites. However, some broken FTP clients such as "ncftp" and "mirror" assume
+      # the presence of the "-R" option, so there is a strong case for enabling it.
+      #ls_recurse_enable=YES
+      #
+      # When "listen" directive is enabled, vsftpd runs in standalone mode and
+      # listens on IPv4 sockets. This directive cannot be used in conjunction
+      # with the listen_ipv6 directive.
+      listen=YES
+      listen_port=2121
+      #
+      # This directive enables listening on IPv6 sockets. To listen on IPv4 and IPv6
+      # sockets, you must run two copies of vsftpd with two configuration files.
+      # Make sure, that one of the listen options is commented !!
+      #listen_ipv6=YES
+
+      pam_service_name=vsftpd
+      userlist_enable=YES
+      tcp_wrappers=YES
+
+      # Passive config
+      pasv_enable=YES
+      pasv_max_port=${ext_passive_ports_end}
+      pasv_min_port=${ext_passive_ports_start}
+      pasv_address=
+
+
+runcmd:
+  - sed -i '/Required-Start/ s/$/ nfs-watcher httpd/'  /etc/init.d/vsftpd
+  - |
+    az=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+    int_ip=$(dig +short $${az}.${internal_nlb_name})
+    ext_ip=$(dig +short $${az}.${external_nlb_name})
+    sed -i "s/^pasv_address=.*/pasv_address=$${int_ip}/" /etc/vsftpd/vsftpd.conf
+    sed -i "s/^pasv_address=.*/pasv_address=$${ext_ip}/" /etc/vsftpd/vsftpd-external.conf
+  - 'echo "vsftpd: ALL" >> /etc/hosts.allow'
+  - chkconfig vsftpd on

--- a/groups/wck-infrastructure/variables.tf
+++ b/groups/wck-infrastructure/variables.tf
@@ -221,3 +221,33 @@ variable "fe_access_cidrs" {
   description = "List of additional CIDRs requiring access via the internal ALB"
   default     = []
 }
+
+variable "fe_ftp_int_passive_ports_start" {
+  type        = number
+  default     = 60401
+  description = "The starting port that will define the range of ports used for FTP passive mode on the Internal FTP server"
+}
+
+variable "fe_ftp_int_passive_ports_end" {
+  type        = number
+  default     = 60420
+  description = "The ending port that will define the range of ports used for FTP passive mode on the Internal FTP server"
+}
+
+variable "fe_ftp_ext_passive_ports_start" {
+  type        = number
+  default     = 60451
+  description = "The starting port that will define the range of ports used for FTP passive mode on the External FTP server"
+}
+
+variable "fe_ftp_ext_passive_ports_end" {
+  type        = number
+  default     = 60470
+  description = "The ending port that will define the range of ports used for FTP passive mode on the External FTP server"
+}
+
+variable "fe_ftp_root_dir" {
+  type        = string
+  default     = "/mnt/nfs/onsite/wck/"
+  description = "Path for the FTP server's root directory"
+}


### PR DESCRIPTION
Adds supporting variables and locals for resource creation
Adds a new internal & external NLB to sit in front of the existing internal & enternal ALBs
Adds listener and target group configuration to forward NLB traffic either to the instances (FTP) or the ALB (HTTP/HTTPS)
Update ASG configuration to register targets with new target groups
Update ASG security group for updated traffic flow and health checks
Update FE instance user data to install FTP server configurations to serve internal and external traffic
Update internal Route53 entry to use NLB address
Added CloudWatch config to capture and forward FTP server xferlog

Resolves: CM-1161