### PR TITLE
Allow access from test subnets in Live

### DIFF
--- a/groups/wck-infrastructure/alb_internal.tf
+++ b/groups/wck-infrastructure/alb_internal.tf
@@ -11,7 +11,8 @@ module "wck_internal_alb_security_group" {
 
   ingress_cidr_blocks = concat(
     local.admin_cidrs,
-    formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip])
+    formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip]),
+    local.test_cidrs
   )
 
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]

--- a/groups/wck-infrastructure/asg_backend.tf
+++ b/groups/wck-infrastructure/asg_backend.tf
@@ -67,8 +67,7 @@ module "bep_asg" {
   name = "${var.application}-bep"
   # Launch configuration
   lc_name       = "${var.application}-bep-launchconfig"
-#  image_id      = data.aws_ami.wck_bep_ami.id
-  image_id      = "ami-016c675cf5f2f1589"
+  image_id      = data.aws_ami.wck_bep_ami.id
   instance_type = var.bep_instance_size
   security_groups = [
     module.wck_bep_asg_security_group.this_security_group_id,

--- a/groups/wck-infrastructure/asg_backend.tf
+++ b/groups/wck-infrastructure/asg_backend.tf
@@ -67,7 +67,8 @@ module "bep_asg" {
   name = "${var.application}-bep"
   # Launch configuration
   lc_name       = "${var.application}-bep-launchconfig"
-  image_id      = data.aws_ami.wck_bep_ami.id
+#  image_id      = data.aws_ami.wck_bep_ami.id
+  image_id      = "ami-016c675cf5f2f1589"
   instance_type = var.bep_instance_size
   security_groups = [
     module.wck_bep_asg_security_group.this_security_group_id,

--- a/groups/wck-infrastructure/data.tf
+++ b/groups/wck-infrastructure/data.tf
@@ -67,6 +67,10 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "test_cidrs" {
+  path = "aws-accounts/network/shared-services/test_cidr_ranges"
+}
+
 data "vault_generic_secret" "kms_keys" {
   path = "aws-accounts/${var.aws_account}/kms"
 }

--- a/groups/wck-infrastructure/locals.tf
+++ b/groups/wck-infrastructure/locals.tf
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------------------
 locals {
   admin_cidrs = values(data.vault_generic_secret.internal_cidrs.data)
+  test_cidrs  = var.test_access_enable ? jsondecode(data.vault_generic_secret.test_cidrs.data["cidrs"]) : []
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 

--- a/groups/wck-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/wck-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -139,3 +139,5 @@ nfs_mounts = {
 
 # SNS Notifications
 enable_sns_topic = true
+
+test_access_enable = true

--- a/groups/wck-infrastructure/variables.tf
+++ b/groups/wck-infrastructure/variables.tf
@@ -251,3 +251,9 @@ variable "fe_ftp_root_dir" {
   default     = "/mnt/nfs/onsite/wck/"
   description = "Path for the FTP server's root directory"
 }
+
+variable "test_access_enable" {
+  type        = bool
+  description = "Controls whether access from the Test subnets is required (true) or not (false)"
+  default     = false
+}


### PR DESCRIPTION
Added support to optionally allow access from test subnets via internal ALB
Added local to conditionally construct the list of CIDRs
Updated internal ALB SG to include the CIDRs
Enabled access for Live

Resolves: INC0365535